### PR TITLE
warning fixes

### DIFF
--- a/examples/admin.c
+++ b/examples/admin.c
@@ -4,6 +4,7 @@
  * See COPYRIGHT in top-level directory.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <margo.h>
 #include <alpha/alpha-admin.h>

--- a/examples/client.c
+++ b/examples/client.c
@@ -4,6 +4,7 @@
  * See COPYRIGHT in top-level directory.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <margo.h>
 #include <assert.h>
 #include <alpha/alpha-client.h>

--- a/src/provider.c
+++ b/src/provider.c
@@ -270,8 +270,8 @@ static void alpha_create_resource_ult(hg_handle_t h)
     margo_debug(provider->mid, "Created resource %s of type \"%s\"", id_str, in.type);
 
 finish:
-    ret = margo_respond(h, &out);
-    ret = margo_free_input(h, &in);
+    hret = margo_respond(h, &out);
+    hret = margo_free_input(h, &in);
     margo_destroy(h);
 }
 static DEFINE_MARGO_RPC_HANDLER(alpha_create_resource_ult)

--- a/src/types.h
+++ b/src/types.h
@@ -6,6 +6,7 @@
 #ifndef _PARAMS_H
 #define _PARAMS_H
 
+#include <stdlib.h>
 #include <mercury.h>
 #include <mercury_macros.h>
 #include <mercury_proc.h>


### PR DESCRIPTION
with gcc-11.2 I got a few warnings using the template
- malloc/calloc/free and exit are part of stdlib.h
- the margo routines were using the wrong variable to save the return code